### PR TITLE
Changed generation of words for games

### DIFF
--- a/src/transfer.sh
+++ b/src/transfer.sh
@@ -1,3 +1,1 @@
-cd "$(dirname "$0")"
-export PYTHONPATH="${PYTHONPATH}:$(pwd):$(pwd)/preprocessing"
-python3 preprocessing/data_migration.py snowman
+python3 preprocessing/data_migration.py airplane angel ant axe bathtub beach bee "birthday cake" book bus butterfly calculator camel castle cat cow crab crocodile diamond elephant eye "frying pan" giraffe hammer hand helicopter horse hospital key lightning mermaid mountain ocean "palm tree" piano pineapple pizza "police car" screwdriver sheep snail suitcase tractor watermelon wheel wristwatch

--- a/src/transfer.sh
+++ b/src/transfer.sh
@@ -1,1 +1,3 @@
-python3 preprocessing/data_migration.py airplane angel ant axe bathtub beach bee "birthday cake" book bus butterfly calculator camel castle cat cow crab crocodile diamond elephant eye "frying pan" giraffe hammer hand helicopter horse hospital key lightning mermaid mountain ocean "palm tree" piano pineapple pizza "police car" screwdriver sheep snail suitcase tractor watermelon wheel wristwatch
+cd "$(dirname "$0")"
+export PYTHONPATH="${PYTHONPATH}:$(pwd):$(pwd)/preprocessing"
+python3 preprocessing/data_migration.py snowman

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -482,8 +482,11 @@ def get_n_labels(n, difficulty_id):
     try:
 
         # get labels from three most recent games
-        games = Games.query.filter(Games.difficulty_id <= difficulty_id, difficulty_id
-                                   - Games.difficulty_id < 2).order_by(Games.date.desc()).limit(3).all()
+        games = Games.query.filter(
+            Games.difficulty_id <= difficulty_id,
+            difficulty_id
+            - Games.difficulty_id < 2).order_by(
+            Games.date.desc()).limit(3).all()
         labels_to_filter = [
             label for game in games for label in json.loads(game.labels)]
 
@@ -494,7 +497,8 @@ def get_n_labels(n, difficulty_id):
 
         minimum_labels = 6
         for label in labels_to_filter:
-            if label in english_labels and len(english_labels) > minimum_labels:
+            if label in english_labels and len(
+                    english_labels) > minimum_labels:
                 english_labels.remove(label)
 
         random_list = random.sample(english_labels, n)

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -9,6 +9,7 @@ import os
 import random
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug import exceptions as excp
+import json
 
 db = SQLAlchemy()
 
@@ -479,11 +480,25 @@ def get_n_labels(n, difficulty_id):
         Reads all rows from database and chooses n random labels in a list.
     """
     try:
+
+        # get labels from three most recent games
+        games = Games.query.filter(Games.difficulty_id <= difficulty_id, difficulty_id
+                                   - Games.difficulty_id < 2).order_by(Games.date.desc()).limit(3).all()
+        labels_to_filter = [
+            label for game in games for label in json.loads(game.labels)]
+
         # read all english labels in database
         labels = Labels.query.filter(
             Labels.difficulty_id <= difficulty_id).all()
         english_labels = [str(label.english) for label in labels]
+
+        minimum_labels = 6
+        for label in labels_to_filter:
+            if label in english_labels and len(english_labels) > minimum_labels:
+                english_labels.remove(label)
+
         random_list = random.sample(english_labels, n)
+
         return random_list
 
     except Exception as e:

--- a/startapp.sh
+++ b/startapp.sh
@@ -2,7 +2,7 @@
 # This script serves as the main interface to the app
 
 # Compute number of gunicorn workers
-ncores=$(nproc)
+ncores=$(sysctl -n hw.logicalcpu)
 nworkers=$(((2*$ncores)+1))
 if [[ $nworkers -gt 12 ]]; then
     nworkers=12

--- a/startapp.sh
+++ b/startapp.sh
@@ -2,7 +2,7 @@
 # This script serves as the main interface to the app
 
 # Compute number of gunicorn workers
-ncores=$(sysctl -n hw.logicalcpu)
+ncores=$(nproc)
 nworkers=$(((2*$ncores)+1))
 if [[ $nworkers -gt 12 ]]; then
     nworkers=12


### PR DESCRIPTION
Simpler PR than first anticipated:

get_n_labels changed in models.py:
- Words from the past three games that has shared words in their word list (e.g. a hard game also uses words from the medium difficulty) wont get repeated in the current game.
- For easy: Filter out words from the past three games on easy difficulty
- For medium: Filter out words from the past three games on easy/medium difficulty
- For hard: Filter out words from the past three games on medium/hard difficulty

Rationale being that someone might play one game on medium, and then change to hard, so its relevant to still filter out words even though difficulty is different (since the two difficulties share some words)

On the topic of the "randomizer", i've considered the random.sample() function to be sufficient, as it uses seeding with current timestamp. Therefore i left it alone, as the word generation should already feel much better with the current changes.