### PR TITLE
Sp24 470 create endpoint sending three images of a specific label

### DIFF
--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -231,6 +231,18 @@ def view_high_score():
     }
     return json.dumps(data), 200
 
+@app.route("/getExampleDrawings", methods=["POST"])
+def get_n_drawings_by_label():
+    """
+        Returns n images from the blob storage container with the given label.
+    """
+    n = request.args.get("n", default=None, type=int)
+    label = request.values["label"]
+
+    images = storage.get_n_random_images_from_label(n, label)
+    return json.dumps(images), 200
+
+
 
 @app.route("/auth", methods=["POST"])
 def authenticate():
@@ -410,3 +422,4 @@ def get_image_resolution(image):
     height, width = Image.open(BytesIO(image.stream.read())).size
     image.seek(0)
     return height, width
+

--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -231,6 +231,7 @@ def view_high_score():
     }
     return json.dumps(data), 200
 
+
 @app.route("/getExampleDrawings", methods=["POST"])
 def get_n_drawings_by_label():
     """
@@ -241,7 +242,6 @@ def get_n_drawings_by_label():
 
     images = storage.get_n_random_images_from_label(n, label)
     return json.dumps(images), 200
-
 
 
 @app.route("/auth", methods=["POST"])
@@ -422,4 +422,3 @@ def get_image_resolution(image):
     height, width = Image.open(BytesIO(image.stream.read())).size
     image.seek(0)
     return height, width
-

--- a/src/webapp/storage.py
+++ b/src/webapp/storage.py
@@ -106,7 +106,7 @@ def blob_connection(container_name=setup.CONTAINER_NAME_NEW):
     """
         Helper method for connection to blob service.
     """
-    
+
     connect_str = Keys.get("BLOB_CONNECTION_STRING")
     try:
         # Instantiate a BlobServiceClient using a connection string
@@ -122,6 +122,7 @@ def blob_connection(container_name=setup.CONTAINER_NAME_NEW):
 
     return container_client
 
+
 def get_n_random_images_from_label(n, label):
     """
         Returns n random images from the blob storage container with the given label.
@@ -134,9 +135,11 @@ def get_n_random_images_from_label(n, label):
     for blob in selected_blobs:
         blob_client = container_client.get_blob_client(blob)
         image_data = blob_client.download_blob().readall()
-        decoded_image = image_to_data_url(image_data, blob.content_settings.content_type)
+        decoded_image = image_to_data_url(
+            image_data, blob.content_settings.content_type)
         images.append(decoded_image)
     return images
+
 
 def image_to_data_url(image_data, content_type):
     """
@@ -144,4 +147,3 @@ def image_to_data_url(image_data, content_type):
     """
     base64_image = base64.b64encode(image_data).decode('utf-8')
     return f"data:{content_type};base64,{base64_image}"
-

--- a/src/webapp/storage.py
+++ b/src/webapp/storage.py
@@ -12,6 +12,8 @@ from azure.storage.blob import BlobClient
 from azure.storage.blob import BlobServiceClient
 from utilities.keys import Keys
 from utilities import setup
+import base64
+import random
 
 
 def save_image(image, label, certainty):
@@ -100,11 +102,11 @@ def image_count():
     return container_client.get_container_properties().metadata["image_count"]
 
 
-def blob_connection():
+def blob_connection(container_name=setup.CONTAINER_NAME_NEW):
     """
         Helper method for connection to blob service.
     """
-    container_name = setup.CONTAINER_NAME_NEW
+    
     connect_str = Keys.get("BLOB_CONNECTION_STRING")
     try:
         # Instantiate a BlobServiceClient using a connection string
@@ -119,3 +121,27 @@ def blob_connection():
         raise Exception("Could not connect to blob client: " + str(e))
 
     return container_client
+
+def get_n_random_images_from_label(n, label):
+    """
+        Returns n random images from the blob storage container with the given label.
+    """
+    container_client = blob_connection(setup.CONTAINER_NAME_ORIGINAL)
+    blob_prefix = f"{label}/"
+    blobs = list(container_client.list_blobs(name_starts_with=blob_prefix))
+    selected_blobs = random.sample(blobs, min(n, len(blobs)))
+    images = []
+    for blob in selected_blobs:
+        blob_client = container_client.get_blob_client(blob)
+        image_data = blob_client.download_blob().readall()
+        decoded_image = image_to_data_url(image_data, blob.content_settings.content_type)
+        images.append(decoded_image)
+    return images
+
+def image_to_data_url(image_data, content_type):
+    """
+        Converts image data to a data URL.
+    """
+    base64_image = base64.b64encode(image_data).decode('utf-8')
+    return f"data:{content_type};base64,{base64_image}"
+


### PR DESCRIPTION
New endpoint "getExampleDrawings" added to backend, returning n amount of images from blob storage for a specified label. 

Two new methods added to storage.py in webapp to assist in this:

- get_n_random_images_from_label retrieves the images from oldimgcontaienr in the blob storage, iterates through all of them (which is something to consider if its a smart idea or not. Has to be done to get completely random images, since the list_blobs() functions lazily loads images) and returns n random ones.
- image_to_data_url() converts the images to data urls which is a good format for the frontend to have them in



