### PR TITLE
Add translation for get example drawings endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config.json
 .vscode/*
 !.vscode/launch.json
 !.vscode/tasks.json
+.venv

--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -241,9 +241,10 @@ def get_n_drawings_by_label():
     """
         Returns n images from the blob storage container with the given label.
     """
-    n = request.args.get("n", default=None, type=int)
-    label = request.values["label"]
-    lang = request.values["lang"]
+    data = request.get_json()
+    n = data["n"]
+    label = data["label"]
+    lang = data["lang"]
 
     if lang == "NO":
         translations = models.get_norwegian_to_english_dict()

--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -243,6 +243,11 @@ def get_n_drawings_by_label():
     """
     n = request.args.get("n", default=None, type=int)
     label = request.values["label"]
+    lang = request.values["lang"]
+
+    if lang == "NO":
+        translations = models.get_norwegian_to_english_dict()
+        label = translations[label]
 
     images = storage.get_n_random_images_from_label(n, label)
     return json.dumps(images), 200

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -565,6 +565,17 @@ def get_translation_dict():
     except Exception as e:
         raise Exception("Could not read Labels table: " + str(e))
 
+def get_norwegian_to_english_dict():
+    """
+        Reads all labels from database and create dictionary
+        that translates from norwegian to english.
+    """
+    try:
+        labels = Labels.query.all()
+        return dict([(str(label.norwegian), str(label.english))
+                    for label in labels])
+    except Exception as e:
+        raise Exception("Could not read Labels table: " + str(e))
 
 def delete_all_tables(app):
     """

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -553,9 +553,10 @@ def to_norwegian(english_label):
             "Could not find translation in Labels table: " + str(e)
         )
 
+
 def to_english(norwegian_label):
     """
-        Reads the labels table and return the english translation of the norwegian label 
+        Reads the labels table and return the english translation of the norwegian label
     """
     try:
         query = Labels.query.filter(Labels.norwegian == norwegian_label)[0]
@@ -565,6 +566,7 @@ def to_english(norwegian_label):
         raise AttributeError(
             "Could not find translation in Labels table: " + str(e)
         )
+
 
 def get_translation_dict():
     """
@@ -576,6 +578,7 @@ def get_translation_dict():
                     for label in labels])
     except Exception as e:
         raise Exception("Could not read Labels table: " + str(e))
+
 
 def delete_all_tables(app):
     """

--- a/startapp.sh
+++ b/startapp.sh
@@ -3,7 +3,6 @@
 
 # Compute number of gunicorn workers
 ncores=$(nproc)
-ncores=$(sysctl -n hw.logicalcpu)
 nworkers=$(((2*$ncores)+1))
 if [[ $nworkers -gt 12 ]]; then
     nworkers=12


### PR DESCRIPTION
# Changes :gem:
_Add dictionary in models that can be used to translate a label from Norwegian to English_
* This is currently used for the "getExampleDrawings"-endpoint

# Notes :book: :pencil2:
_Messed up with the commits on this one, so don't worry too much about that heh.._