### PR TITLE
Sp24 765 scripts to upload to custom vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This also assumes that both Azure Blob Storage and Azure CustomVision is already
 
 ### **Downloading the dataset from Quickdraw and uploading it to blob storage**
 
-1. Downloading the dataset can be done by cding into preprocessing, and running `gsutil -m cp gs://quickdraw_dataset/full/simplified/*.ndjson ./data`. 
+1. Downloading the entire dataset can be done by cding into preprocessing, and running `gsutil -m cp gs://quickdraw_dataset/full/simplified/*.ndjson ./data`. The `*` can be replaced by the name of a category if you want to download just one specific category. If you want to only download the categories that are currently used in the game, you can run `bash download_quick_draw.sh` from the folder src/preprocessing. A csv-file with category names can also be provided as a command line argument to this script.
 
 Note that the entire dataset is around ~22GB. More info on the dataset can be found on the [Github page](https://github.com/googlecreativelab/quickdraw-dataset#get-the-data).
 
@@ -67,9 +67,10 @@ While it is not the same python library, the documentation for [pycairo](https:/
 
 3. Install the *cairocffi* package with `pip install cairocffi`
 
-4. Open `transfer.sh` from in the src folder, and type in the words you want to migrate to the blob storage
-
-5. Run `bash transfer.sh` from the src folder once the script is read
+4. Run `bash upload_to_blob.sh`. This uploads images from the categories used in the current version of the game. You can also provide your own csv-file with
+category names as a command line argument. Available options are 
+  - `--categories`: should be a csv-file containing the categories you wish to upload.
+  - `--num_images`: the number of images you want to upload from each category. The default is 50.
 
 Assuming everything runs without errors, the images should now be in the blob storage
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This also assumes that both Azure Blob Storage and Azure CustomVision is already
 
 ### **Downloading the dataset from Quickdraw and uploading it to blob storage**
 
-1. Downloading the entire dataset can be done by cding into preprocessing, and running `gsutil -m cp gs://quickdraw_dataset/full/simplified/*.ndjson ./data`. The `*` can be replaced by the name of a category if you want to download just one specific category. If you want to only download the categories that are currently used in the game, you can run `bash download_quick_draw.sh` from the folder src/preprocessing. A csv-file with category names can also be provided as a command line argument to this script.
+1. Downloading the entire dataset can be done by cding into preprocessing, and running `gsutil -m cp gs://quickdraw_dataset/full/simplified/*.ndjson ./data`. The `*` can be replaced by the name of a category if you want to download just one specific category. If you want to only download the categories that are currently used in the game, you can run `bash download_quick_draw.sh` from the folder `src/preprocessing`. A csv-file with category names can also be provided as a command line argument to this script.
 
 Note that the entire dataset is around ~22GB. More info on the dataset can be found on the [Github page](https://github.com/googlecreativelab/quickdraw-dataset#get-the-data).
 
@@ -67,26 +67,19 @@ While it is not the same python library, the documentation for [pycairo](https:/
 
 3. Install the *cairocffi* package with `pip install cairocffi`
 
-4. Run `bash upload_to_blob.sh`. This uploads images from the categories used in the current version of the game. You can also provide your own csv-file with
+4. Run `bash upload_to_blob.sh` from the src folder. This uploads images from the categories used in the current version of the game. You can also provide your own csv-file with
 category names as a command line argument. Available options are 
-  - `--categories`: should be a csv-file containing the categories you wish to upload.
-  - `--num_images`: the number of images you want to upload from each category. The default is 50.
+    - `--categories`: should be a csv-file containing the categories you wish to upload.
+    - `--num_images`: the number of images you want to upload from each category. The default is 50.
 
 Assuming everything runs without errors, the images should now be in the blob storage
 
 ### **Uploading the data to Azure CustomVision and training an iteration of the classification model**
 
-There is not a specific script to do this step, but both functions are ready for use in `src/customvision/classifier.py`. The classifier class is also initizalied in `src/webapp/api.py`, meaning the data can be uploaded and trained on there.
+1. Run `bash upload_to_CV.sh` from the `src/customvision` folder. This will upload all photos from Blob storage from the categories in the current version of the Custom Vision model.
+Optionally, you can provide a csv-file containing the categories you want to upload as a command line argument to this script.
 
-1. Add the lines for uploading images to api.py, so it looks something like the code below. "labels" is the list of labels to be trained on, e.g. ["airplane", "apple", "ant"]
-
-        # Initialize CV classifier
-        classifier = Classifier()
-        classifier.upload_images(labels, "oldimgcontainer")
-
-2. Run `startapp.sh` once, assuming the images gets uploaded without error, the upload_images line should be removed before running `startapp.sh` again later.
-
-3. Go to [customvision.ai](customvision.ai), and click on the `Train` button in the top right after entering the correct project. For most use cases, `Quick Training` can be chosen here.
+2. Go to [customvision.ai](customvision.ai), and click on the `Train` button in the top right after entering the correct project. For most use cases, `Quick Training` can be chosen here.
 
 
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Assuming everything runs without errors, the images should now be in the blob st
 
 ### **Uploading the data to Azure CustomVision and training an iteration of the classification model**
 
-1. Run `bash upload_to_CV.sh` from the `src/customvision` folder. This will upload all photos from Blob storage from the categories in the current version of the Custom Vision model.
+1. Run `bash custom_vision/upload_to_CV.sh` from the `src` folder. This will upload all photos from Blob storage from the categories in the current version of the Custom Vision model.
 Optionally, you can provide a csv-file containing the categories you want to upload as a command line argument to this script.
 
 2. Go to [customvision.ai](customvision.ai), and click on the `Train` button in the top right after entering the correct project. For most use cases, `Quick Training` can be chosen here.

--- a/src/customvision/classifier.py
+++ b/src/customvision/classifier.py
@@ -231,8 +231,14 @@ class Classifier:
                 raise AttributeError("no images for this label")
 
             # build correct URLs and append to URL list
+
+            #if base url ends on /, remove it.
+            base_img_url = self.base_img_url
+            if base_img_url[-1] == "/":
+                base_img_url = base_img_url[:-1]
+
             for blob in blob_list:
-                blob_url = f"{self.base_img_url}/{container_name}/{blob.name}"
+                blob_url = f"{base_img_url}/{container_name}/{blob.name}"
                 url_list.append(
                     ImageUrlCreateEntry(url=blob_url, tag_ids=[tag.id])
                 )

--- a/src/customvision/upload.py
+++ b/src/customvision/upload.py
@@ -1,0 +1,9 @@
+from classifier import Classifier
+import argparse
+from utilities.keys import Keys
+import sys
+
+classifier = Classifier()
+labels = sys.argv[1:]
+
+classifier.upload_images(labels, Keys.get("CONTAINER_NAME"))

--- a/src/customvision/upload_to_CV.sh
+++ b/src/customvision/upload_to_CV.sh
@@ -3,6 +3,8 @@ categories=""
 input="dict_eng_to_nor_difficulties_v2.csv"
 pattern=" |'"
 
+# if there is a command line argument, use this as the csv-file to 
+# read categories instead.
 if [ $# -gt 0 ]
   then
     input=$1
@@ -18,7 +20,6 @@ do
     fi
   done < "$input"
 
-  echo $categories
 
 
 python3 customvision/upload.py $categories

--- a/src/customvision/upload_to_CV.sh
+++ b/src/customvision/upload_to_CV.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-categories=""
 input="dict_eng_to_nor_difficulties_v2.csv"
 pattern=" |'"
 
@@ -10,16 +9,12 @@ if [ $# -gt 0 ]
     input=$1
 fi
 
+categories_arr=()
+
 while IFS=',' read -a line
 do
-    if [[ ${line[0]} =~ $pattern ]]
-    then
-      categories="${categories} \"${line[0]}\""
-    else 
-      categories="${categories} ${line[0]}"
-    fi
+    categories_arr+=( "${line[0]}" )
   done < "$input"
 
 
-
-python3 customvision/upload.py $categories
+python3 customvision/upload.py "${categories_arr[@]}"

--- a/src/customvision/upload_to_CV.sh
+++ b/src/customvision/upload_to_CV.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+categories=""
+input="dict_eng_to_nor_difficulties_v2.csv"
+pattern=" |'"
+
+if [ $# -gt 0 ]
+  then
+    input=$1
+fi
+
+while IFS=',' read -a line
+do
+    if [[ ${line[0]} =~ $pattern ]]
+    then
+      categories="${categories} \"${line[0]}\""
+    else 
+      categories="${categories} ${line[0]}"
+    fi
+  done < "$input"
+
+  echo $categories
+
+
+python3 customvision/upload.py $categories

--- a/src/preprocessing/data_migration.py
+++ b/src/preprocessing/data_migration.py
@@ -111,7 +111,7 @@ def get_images_from_class(className, N=100):
     """
         Retrieve images from the class provided.
     """
-    path = f"./preprocessing/data/{className}.ndjson"
+    path = f"./preprocessing/images/{className}.ndjson"
     lines = []
     with open(path) as f:
         while len(lines) < N:
@@ -129,7 +129,7 @@ def get_classnames():
         Retrieve class names.
     """
     classname = []
-    for file in os.listdir("./preprocessing/data"):
+    for file in os.listdir("./preprocessing/images"):
         if file.endswith(".ndjson"):
             classname.append(str(file)[:-7])
 

--- a/src/preprocessing/download_quick_draw.sh
+++ b/src/preprocessing/download_quick_draw.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
-input="../dict_eng_to_nor_difficulties_v2.csv"
+categories=""
+input="dict_eng_to_nor_difficulties_v2.csv"
+pattern=" |'"
+
+# if there is a command line argument, use this as the csv-file to 
+# read categories instead.
+if [ $# -gt 0 ]
+  then
+    input=$1
+fi
+
 while IFS=',' read -ra
  line
 do
-  gsutil -m cp gs://quickdraw_dataset/full/simplified/"${line[0]}".ndjson ./images/"$line".ndjson
-  echo "$line"
+  gsutil -m cp gs://quickdraw_dataset/full/simplified/"${line[0]}".ndjson ./images/"${line[0]}".ndjson
 done < "$input"

--- a/src/preprocessing/download_quick_draw.sh
+++ b/src/preprocessing/download_quick_draw.sh
@@ -10,8 +10,7 @@ if [ $# -gt 0 ]
     input=$1
 fi
 
-while IFS=',' read -ra
- line
+while IFS=',' read -a line
 do
   gsutil -m cp gs://quickdraw_dataset/full/simplified/"${line[0]}".ndjson ./images/"${line[0]}".ndjson
 done < "$input"

--- a/src/preprocessing/download_quick_draw.sh
+++ b/src/preprocessing/download_quick_draw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 categories=""
-input="dict_eng_to_nor_difficulties_v2.csv"
+input="../dict_eng_to_nor_difficulties_v2.csv"
 pattern=" |'"
 
 # if there is a command line argument, use this as the csv-file to 

--- a/src/preprocessing/download_quick_draw.sh
+++ b/src/preprocessing/download_quick_draw.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+input="../dict_eng_to_nor_difficulties_v2.csv"
+while IFS=',' read -ra
+ line
+do
+  gsutil -m cp gs://quickdraw_dataset/full/simplified/"${line[0]}".ndjson ./images/"$line".ndjson
+  echo "$line"
+done < "$input"

--- a/src/upload_to_blob.sh
+++ b/src/upload_to_blob.sh
@@ -2,11 +2,27 @@
 categories=""
 input="dict_eng_to_nor_difficulties_v2.csv"
 pattern=" |'"
+num_img=50
 
-if [ $# -gt 0 ]
-  then
-    input=$1
-fi
+# Process the arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --categories) 
+            input="$2"
+            shift # shift past the argument's value
+            ;;
+        --num_images)
+            num_img="$2"
+            shift # shift past the argument's value
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+    shift # shift past the option
+done
+
 
 while IFS=',' read -a line
 do
@@ -18,4 +34,6 @@ do
     fi
   done < "$input"
 
-python3 preprocessing/data_migration.py $categories
+echo $num_img
+
+python3 preprocessing/data_migration.py $categories -n $num_img

--- a/src/upload_to_blob.sh
+++ b/src/upload_to_blob.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+categories=""
+input="dict_eng_to_nor_difficulties_v2.csv"
+pattern=" |'"
+
+if [ $# -gt 0 ]
+  then
+    input=$1
+fi
+
+while IFS=',' read -a line
+do
+    echo "${line[0]}"
+    if [[ ${line[0]} =~ $pattern ]]
+    then
+      categories="${categories} \"${line[0]}\""
+    else 
+      categories="${categories} ${line[0]}"
+    fi
+  done < "$input"
+
+python3 preprocessing/data_migration.py $categories

--- a/src/upload_to_blob.sh
+++ b/src/upload_to_blob.sh
@@ -34,6 +34,4 @@ do
     fi
   done < "$input"
 
-echo $num_img
-
 python3 preprocessing/data_migration.py $categories -n $num_img

--- a/src/upload_to_blob.sh
+++ b/src/upload_to_blob.sh
@@ -10,7 +10,6 @@ fi
 
 while IFS=',' read -a line
 do
-    echo "${line[0]}"
     if [[ ${line[0]} =~ $pattern ]]
     then
       categories="${categories} \"${line[0]}\""


### PR DESCRIPTION
Created bash scripts to make it easier to train the image recognition model with different training data. There are now scripts for downloading the Quick Draw dataset, uploading those images to Blob Storage and transferring images from Blob Storage to Custom Vision. A csv-file with the categories you wish to upload can be provided to all these scripts, and the number of images can be specified as a command line argument as well. Everything is explained in the README file.