### PR TITLE
remove dependency on db in Classifier

### DIFF
--- a/src/customvision/classifier.py
+++ b/src/customvision/classifier.py
@@ -83,11 +83,8 @@ class Classifier:
             # get the latest published iteration
             puplished_iterations.sort(key=lambda i: i.created)
             self.iteration_name = puplished_iterations[-1].publish_name
-
-            with app.app_context():
-                models.update_iteration_name(self.iteration_name)
         except Exception as e:
-            logging.info(e)
+            logging.info("An error occurred while trying to get latest published iteration from Custom Vision", e)
             self.iteration_name = "Iteration4"
 
     def predict_image_url(self, img_url: str) -> Dict[str, float]:
@@ -101,8 +98,6 @@ class Classifier:
             (prediction (dict[str,float]): labels and assosiated probabilities,
             best_guess: (str): name of the label with highest probability)
         """
-        with app.app_context():
-            self.iteration_name = models.get_iteration_name()
         res = self.predictor.classify_image_url(
             project_id=self.project_id,
             published_name=self.iteration_name,

--- a/src/customvision/classifier.py
+++ b/src/customvision/classifier.py
@@ -124,8 +124,6 @@ class Classifier:
             (prediction (dict[str,float]): labels and assosiated probabilities,
             best_guess: (str): name of the label with highest probability)
         """
-        with app.app_context():
-            self.iteration_name = models.get_iteration_name()
         res = self.predictor.classify_image_with_no_store(
             self.project_id, self.iteration_name, img
         )
@@ -343,8 +341,6 @@ class Classifier:
             iteration_name,
             self.prediction_resource_id,
         )
-        with app.app_context():
-            self.iteration_name = models.update_iteration_name(iteration_name)
 
     def delete_all_images(self) -> None:
         """


### PR DESCRIPTION
Fjerna at Classifier oppdaterer databasen med iteration_name. Den henter i stedet fra instansvariabel i klassen. Det virker unødvendig å snakke med databasen kun for å lagre navnet, man sjekker jo med Custom Vision uansett for å se om det er en ny publisert iterasjon hver gang klassen initialiseres.